### PR TITLE
feat(facturacion): CRUD completo de Clientes + mejoras carrito lateral

### DIFF
--- a/facturacion/forms.py
+++ b/facturacion/forms.py
@@ -2,7 +2,64 @@ from django import forms
 from .models import Cliente
 
 
+BS_INPUT = {"class": "form-control"}
+BS_SELECT = {"class": "form-select"}
+
+
 class ClienteForm(forms.ModelForm):
+    """Formulario completo de Cliente usado para alta y edición."""
+
     class Meta:
         model = Cliente
         fields = "__all__"
+        widgets = {
+            "razon_social": forms.TextInput(attrs=BS_INPUT),
+            "cuit_dni": forms.TextInput(attrs=BS_INPUT),
+            "responsabilidad_iva": forms.Select(attrs=BS_SELECT),
+            "tipo_documento": forms.Select(attrs=BS_SELECT),
+            "domicilio": forms.TextInput(attrs=BS_INPUT),
+            "telefono": forms.TextInput(attrs=BS_INPUT),
+        }
+
+
+class ClienteQuickForm(forms.ModelForm):
+    """Formulario para alta rápida desde el buscador (todos los campos del modelo)."""
+
+    class Meta:
+        model = Cliente
+        fields = "__all__"
+        widgets = {
+            "razon_social": forms.TextInput(attrs=BS_INPUT),
+            "cuit_dni": forms.TextInput(attrs=BS_INPUT),
+            "responsabilidad_iva": forms.Select(attrs=BS_SELECT),
+            "tipo_documento": forms.Select(attrs=BS_SELECT),
+            "domicilio": forms.TextInput(attrs=BS_INPUT),
+            "telefono": forms.TextInput(attrs=BS_INPUT),
+        }
+
+
+class ClienteFilterForm(forms.Form):
+    """Filtros del listado de clientes."""
+
+    q = forms.CharField(
+        required=False,
+        label="Razón social",
+        widget=forms.TextInput(attrs={**BS_INPUT, "placeholder": "Razón social"}),
+    )
+    cuit = forms.CharField(
+        required=False,
+        label="CUIT/DNI",
+        widget=forms.TextInput(attrs={**BS_INPUT, "placeholder": "CUIT/DNI"}),
+    )
+    iva = forms.ChoiceField(
+        required=False,
+        label="Resp. IVA",
+        choices=[("", "Todas")] + Cliente.RESPONSABILIDAD_IVA_OPCIONES,
+        widget=forms.Select(attrs=BS_SELECT),
+    )
+    tdoc = forms.ChoiceField(
+        required=False,
+        label="Tipo doc.",
+        choices=[("", "Todos")] + Cliente.TIPO_DOCUMENTO_OPCIONES,
+        widget=forms.Select(attrs=BS_SELECT),
+    )

--- a/facturacion/templates/facturacion/cliente_form_page.html
+++ b/facturacion/templates/facturacion/cliente_form_page.html
@@ -1,0 +1,35 @@
+{% extends 'base2.html' %}
+
+{% block title %}{{ titulo }}{% endblock %}
+
+{% block form_content %}
+<div class="d-flex justify-content-between align-items-center">
+    <h1 class="mb-0">{{ titulo }}</h1>
+    <a href="{% url 'clientes-list' %}" class="btn btn-outline-secondary">Volver al listado</a>
+</div>
+{% endblock %}
+
+{% block base_content %}
+<div class="row justify-content-center">
+    <div class="col-lg-8">
+        <form method="post" novalidate>
+            {% csrf_token %}
+            {% if form.non_field_errors %}
+                <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+            {% endif %}
+            {% for field in form %}
+                <div class="mb-3">
+                    <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
+                    {{ field }}
+                    {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
+                    {% if field.errors %}<div class="invalid-feedback d-block">{{ field.errors|join:', ' }}</div>{% endif %}
+                </div>
+            {% endfor %}
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">{{ accion_label }}</button>
+                <a href="{% url 'clientes-list' %}" class="btn btn-outline-secondary">Cancelar</a>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/facturacion/templates/facturacion/clientes_list.html
+++ b/facturacion/templates/facturacion/clientes_list.html
@@ -185,6 +185,32 @@
         });
     });
 
+    // Filtro tipo "select2" para el cliente destino del modal de eliminación
+    document.addEventListener('input', function(e) {
+        if (!e.target || e.target.id !== 'destino_buscar') return;
+        const q = (e.target.value || '').toLowerCase().trim();
+        const select = document.getElementById('destino_id');
+        if (!select) return;
+        let firstVisible = null;
+        Array.from(select.options).forEach(opt => {
+            const match = opt.textContent.toLowerCase().indexOf(q) > -1;
+            opt.hidden = !match;
+            opt.disabled = !match;
+            if (match && !firstVisible) firstVisible = opt;
+        });
+        // Si la opción seleccionada quedó oculta, mover selección a la primera visible
+        const selected = select.options[select.selectedIndex];
+        if (selected && selected.hidden && firstVisible) {
+            select.value = firstVisible.value;
+        }
+    });
+
+    // Foco automático al abrir el modal de eliminación
+    modalEliminarEl.addEventListener('shown.bs.modal', function() {
+        const input = document.getElementById('destino_buscar');
+        if (input) input.focus();
+    });
+
     // Submit del form de edición (delegación)
     document.addEventListener('submit', function(e) {
         const form = e.target;

--- a/facturacion/templates/facturacion/clientes_list.html
+++ b/facturacion/templates/facturacion/clientes_list.html
@@ -1,0 +1,230 @@
+{% extends 'base2.html' %}
+{% load static %}
+
+{% block title %}Clientes{% endblock %}
+
+{% block form_content %}
+<div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+    <div>
+        <h1 class="mb-0">Clientes</h1>
+        <small class="text-muted">Total: {{ total_count }}</small>
+    </div>
+    <div class="d-flex gap-2">
+        <a href="{% url 'clientes-nuevo' %}" class="btn btn-success">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-3px;"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            Nuevo cliente
+        </a>
+        <a href="/buscador/" class="btn btn-outline-secondary">Volver al buscador</a>
+    </div>
+</div>
+
+<form method="get" class="row g-2 mt-3">
+    <div class="col-sm-4">
+        <label class="form-label mb-0 small">Razón social</label>
+        {{ filter_form.q }}
+    </div>
+    <div class="col-sm-3">
+        <label class="form-label mb-0 small">CUIT/DNI</label>
+        {{ filter_form.cuit }}
+    </div>
+    <div class="col-sm-2">
+        <label class="form-label mb-0 small">Resp. IVA</label>
+        {{ filter_form.iva }}
+    </div>
+    <div class="col-sm-2">
+        <label class="form-label mb-0 small">Tipo doc.</label>
+        {{ filter_form.tdoc }}
+    </div>
+    <div class="col-sm-1 d-grid align-items-end">
+        <label class="form-label mb-0 small">&nbsp;</label>
+        <button type="submit" class="btn btn-primary">Filtrar</button>
+    </div>
+    {% if request.GET %}
+    <div class="col-12">
+        <a href="{% url 'clientes-list' %}" class="btn btn-sm btn-link px-0">Limpiar filtros</a>
+    </div>
+    {% endif %}
+</form>
+{% endblock %}
+
+{% block base_content %}
+<div class="table-responsive">
+    <table class="table table-striped table-hover align-middle">
+        <thead class="table-light">
+            <tr>
+                <th style="width:60px;">ID</th>
+                <th>Razón social</th>
+                <th>CUIT/DNI</th>
+                <th>Resp. IVA</th>
+                <th>Tipo doc.</th>
+                <th>Teléfono</th>
+                <th>Domicilio</th>
+                <th class="text-end" style="width:130px;">Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for cliente in page_obj %}
+            <tr data-cliente-id="{{ cliente.id }}">
+                <td>{{ cliente.id }}</td>
+                <td>{{ cliente.razon_social }}</td>
+                <td>{{ cliente.cuit_dni }}</td>
+                <td>{{ cliente.get_responsabilidad_iva_display }}</td>
+                <td>{{ cliente.get_tipo_documento_display }}</td>
+                <td>{{ cliente.telefono|default:"—" }}</td>
+                <td>{{ cliente.domicilio|default:"—" }}</td>
+                <td class="text-end">
+                    <button class="btn btn-sm btn-outline-primary btn-editar-cliente"
+                            data-id="{{ cliente.id }}"
+                            title="Editar" aria-label="Editar">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>
+                    </button>
+                    <button class="btn btn-sm btn-outline-danger btn-eliminar-cliente"
+                            data-id="{{ cliente.id }}"
+                            {% if cliente.id == 1 %}disabled title="No se puede eliminar Consumidor Final"{% else %}title="Eliminar" aria-label="Eliminar"{% endif %}>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg>
+                    </button>
+                </td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="8" class="text-center text-muted py-4">Sin resultados</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+{% if page_obj.paginator.num_pages > 1 %}
+<nav aria-label="Paginación" class="d-flex justify-content-between align-items-center">
+    <small class="text-muted">
+        Página {{ page_obj.number }} de {{ page_obj.paginator.num_pages }}
+    </small>
+    <ul class="pagination mb-0">
+        <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}">
+            {% if page_obj.has_previous %}
+                <a class="page-link" href="?{% if preserved_qs %}{{ preserved_qs }}&{% endif %}page={{ page_obj.previous_page_number }}">Anterior</a>
+            {% else %}
+                <span class="page-link">Anterior</span>
+            {% endif %}
+        </li>
+        <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}">
+            {% if page_obj.has_next %}
+                <a class="page-link" href="?{% if preserved_qs %}{{ preserved_qs }}&{% endif %}page={{ page_obj.next_page_number }}">Siguiente</a>
+            {% else %}
+                <span class="page-link">Siguiente</span>
+            {% endif %}
+        </li>
+    </ul>
+</nav>
+{% endif %}
+
+<!-- Modal: Editar cliente -->
+<div class="modal fade" id="modalEditarCliente" tabindex="-1" aria-labelledby="modalEditarClienteLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalEditarClienteLabel">Editar cliente</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body" id="modalEditarClienteBody">
+                <div class="text-center text-muted py-4">Cargando...</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal: Eliminar cliente -->
+<div class="modal fade" id="modalEliminarCliente" tabindex="-1" aria-labelledby="modalEliminarClienteLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalEliminarClienteLabel">Eliminar cliente</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body" id="modalEliminarClienteBody">
+                <div class="text-center text-muted py-4">Cargando...</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+(function(){
+    function getCookie(name) {
+        const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+        return match ? decodeURIComponent(match[1]) : null;
+    }
+    const csrftoken = getCookie('csrftoken');
+
+    const modalEditarEl = document.getElementById('modalEditarCliente');
+    const modalEliminarEl = document.getElementById('modalEliminarCliente');
+    const modalEditar = new bootstrap.Modal(modalEditarEl);
+    const modalEliminar = new bootstrap.Modal(modalEliminarEl);
+
+    function loadInto(url, bodyEl) {
+        bodyEl.innerHTML = '<div class="text-center text-muted py-4">Cargando...</div>';
+        return fetch(url, {headers: {'X-Requested-With': 'XMLHttpRequest'}})
+            .then(r => r.text())
+            .then(html => { bodyEl.innerHTML = html; });
+    }
+
+    // Editar
+    document.querySelectorAll('.btn-editar-cliente').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const id = btn.dataset.id;
+            loadInto(`/facturacion/clientes/editar/${id}/`, document.getElementById('modalEditarClienteBody'))
+                .then(() => modalEditar.show());
+        });
+    });
+
+    // Eliminar
+    document.querySelectorAll('.btn-eliminar-cliente').forEach(btn => {
+        if (btn.disabled) return;
+        btn.addEventListener('click', () => {
+            const id = btn.dataset.id;
+            loadInto(`/facturacion/clientes/eliminar/${id}/`, document.getElementById('modalEliminarClienteBody'))
+                .then(() => modalEliminar.show());
+        });
+    });
+
+    // Submit del form de edición (delegación)
+    document.addEventListener('submit', function(e) {
+        const form = e.target;
+        if (form && form.matches('#formEditarCliente')) {
+            e.preventDefault();
+            const data = new FormData(form);
+            fetch(form.action, {
+                method: 'POST',
+                body: data,
+                headers: {'X-Requested-With': 'XMLHttpRequest', 'X-CSRFToken': csrftoken},
+            }).then(async r => {
+                if (r.ok) {
+                    modalEditar.hide();
+                    window.location.reload();
+                } else {
+                    const payload = await r.json().catch(() => ({}));
+                    if (payload && payload.html) {
+                        document.getElementById('modalEditarClienteBody').innerHTML = payload.html;
+                    }
+                }
+            });
+        }
+        if (form && form.matches('#formEliminarCliente')) {
+            e.preventDefault();
+            const data = new FormData(form);
+            fetch(form.action, {
+                method: 'POST',
+                body: data,
+                headers: {'X-Requested-With': 'XMLHttpRequest', 'X-CSRFToken': csrftoken},
+            }).then(async r => {
+                const payload = await r.json().catch(() => ({}));
+                if (r.ok && payload.ok) {
+                    modalEliminar.hide();
+                    window.location.reload();
+                } else {
+                    alert((payload && payload.error) || 'Error al eliminar');
+                }
+            });
+        }
+    });
+})();
+</script>
+{% endblock %}

--- a/facturacion/templates/facturacion/partials/cliente_delete.html
+++ b/facturacion/templates/facturacion/partials/cliente_delete.html
@@ -17,7 +17,13 @@
 
     <div class="mb-3">
         <label for="destino_id" class="form-label">Cliente destino para las transacciones</label>
-        <select id="destino_id" name="destino_id" class="form-select" required>
+        <div class="input-group input-group-sm mb-2">
+            <span class="input-group-text">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            </span>
+            <input type="text" id="destino_buscar" class="form-control" placeholder="Buscar por razón social o CUIT/DNI..." autocomplete="off">
+        </div>
+        <select id="destino_id" name="destino_id" class="form-select" size="6" required>
             {% for destino in destinos %}
                 <option value="{{ destino.id }}" {% if destino.id == default_destino_id %}selected{% endif %}>
                     {{ destino.razon_social }} ({{ destino.cuit_dni }}){% if destino.id == 1 %} — Consumidor Final{% endif %}

--- a/facturacion/templates/facturacion/partials/cliente_delete.html
+++ b/facturacion/templates/facturacion/partials/cliente_delete.html
@@ -1,0 +1,34 @@
+{% load static %}
+<form id="formEliminarCliente" method="post" action="{{ action_url }}">
+    {% csrf_token %}
+    <p>
+        ¿Confirmás eliminar al cliente
+        <strong>{{ cliente.razon_social }}</strong>
+        <span class="text-muted">(id={{ cliente.id }}, CUIT/DNI: {{ cliente.cuit_dni }})</span>?
+    </p>
+    {% if transacciones_count %}
+        <div class="alert alert-warning">
+            Este cliente tiene <strong>{{ transacciones_count }}</strong> transacción{{ transacciones_count|pluralize:"es" }} asociada{{ transacciones_count|pluralize }}.
+            Seleccioná el cliente destino al que se reasignarán antes de eliminar.
+        </div>
+    {% else %}
+        <div class="alert alert-info">Este cliente no tiene transacciones asociadas.</div>
+    {% endif %}
+
+    <div class="mb-3">
+        <label for="destino_id" class="form-label">Cliente destino para las transacciones</label>
+        <select id="destino_id" name="destino_id" class="form-select" required>
+            {% for destino in destinos %}
+                <option value="{{ destino.id }}" {% if destino.id == default_destino_id %}selected{% endif %}>
+                    {{ destino.razon_social }} ({{ destino.cuit_dni }}){% if destino.id == 1 %} — Consumidor Final{% endif %}
+                </option>
+            {% endfor %}
+        </select>
+        <div class="form-text">Por defecto se reasignan al Consumidor Final (id=1).</div>
+    </div>
+
+    <div class="d-flex justify-content-end gap-2">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="submit" class="btn btn-danger">Eliminar y reasignar</button>
+    </div>
+</form>

--- a/facturacion/templates/facturacion/partials/cliente_form.html
+++ b/facturacion/templates/facturacion/partials/cliente_form.html
@@ -1,0 +1,22 @@
+{% load static %}
+<form id="formEditarCliente" method="post" action="{{ action_url }}" novalidate>
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+        <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+    {% endif %}
+    <div class="row">
+        {% for field in form %}
+            <div class="mb-3 col-md-6">
+                <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
+                {{ field }}
+                {% if field.errors %}
+                    <div class="invalid-feedback d-block">{{ field.errors|join:', ' }}</div>
+                {% endif %}
+            </div>
+        {% endfor %}
+    </div>
+    <div class="d-flex justify-content-end gap-2">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="submit" class="btn btn-primary">Guardar</button>
+    </div>
+</form>

--- a/facturacion/urls.py
+++ b/facturacion/urls.py
@@ -18,6 +18,13 @@ from facturacion.views import (
     FacturacionMensual,
     consulta_impresora_fiscal_generica,
 )
+from facturacion.views_clientes import (
+    ClientesListView,
+    ClienteNuevoView,
+    ClienteEditarView,
+    ClienteEliminarView,
+    api_crear_cliente,
+)
 
 urlpatterns = [
     path("obtener_metodos_pago/", obtener_metodos_pago, name="obtener_metodos_pago"),
@@ -45,7 +52,34 @@ urlpatterns = [
         name="actualizar_cantidad_articulo_sin_registro",
     ),
     path("vista_cierre_z/", CierreZVieW.as_view(), name="cierres-fiscales"),
-    path("facturacion/clientes/", Clientes.as_view(), name="clientes"),
+    # CRUD de clientes
+    path(
+        "facturacion/clientes/",
+        ClientesListView.as_view(),
+        name="clientes-list",
+    ),
+    path(
+        "facturacion/clientes/nuevo/",
+        ClienteNuevoView.as_view(),
+        name="clientes-nuevo",
+    ),
+    path(
+        "facturacion/clientes/editar/<int:id>/",
+        ClienteEditarView.as_view(),
+        name="clientes-editar",
+    ),
+    path(
+        "facturacion/clientes/eliminar/<int:id>/",
+        ClienteEliminarView.as_view(),
+        name="clientes-eliminar",
+    ),
+    path(
+        "facturacion/clientes/api/crear/",
+        api_crear_cliente,
+        name="clientes-api-crear",
+    ),
+    # Alias legado: mantener la url antigua operativa apuntando al listado
+    path("facturacion/clientes/legacy/", Clientes.as_view(), name="clientes"),
     path("facturacion/", Facturacion.as_view(), name="facturacion"),
     path(
         "facturacion/mensual/", FacturacionMensual.as_view(), name="facturacion-mensual"

--- a/facturacion/views_clientes.py
+++ b/facturacion/views_clientes.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+"""CRUD de Clientes para la app de facturación.
+
+Incluye:
+- Listado con filtros y paginación.
+- Alta (página dedicada y endpoint JSON para alta rápida desde el buscador).
+- Edición (página completa y fragmento para modal AJAX).
+- Eliminación con reasignación de transacciones a un cliente destino.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from django.core.paginator import Paginator
+from django.db import transaction as db_transaction
+from django.db.models import Count, Q
+from django.http import HttpResponse, JsonResponse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
+from django.views.decorators.http import require_GET, require_POST
+from django.views.generic import TemplateView
+
+from .forms import ClienteFilterForm, ClienteForm, ClienteQuickForm
+from .funtions import cliente_to_dict
+from .models import Cliente, Transaccion
+
+logger = logging.getLogger(__name__)
+
+PAGE_SIZE_DEFAULT = 25
+CONSUMIDOR_FINAL_ID = 1
+
+
+def _is_ajax(request) -> bool:
+    return request.headers.get("x-requested-with") == "XMLHttpRequest"
+
+
+# ========================
+# Listado
+# ========================
+class ClientesListView(TemplateView):
+    """Listado de clientes con filtros, paginación y acciones."""
+
+    template_name = "facturacion/clientes_list.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        request = self.request
+        filter_form = ClienteFilterForm(request.GET or None)
+        qs = Cliente.objects.all().order_by("razon_social")
+
+        if filter_form.is_valid():
+            q = filter_form.cleaned_data.get("q")
+            cuit = filter_form.cleaned_data.get("cuit")
+            iva = filter_form.cleaned_data.get("iva")
+            tdoc = filter_form.cleaned_data.get("tdoc")
+            if q:
+                qs = qs.filter(razon_social__icontains=q)
+            if cuit:
+                qs = qs.filter(cuit_dni__icontains=cuit)
+            if iva:
+                qs = qs.filter(responsabilidad_iva=iva)
+            if tdoc:
+                qs = qs.filter(tipo_documento=tdoc)
+
+        try:
+            page_size = int(request.GET.get("page_size") or PAGE_SIZE_DEFAULT)
+        except (TypeError, ValueError):
+            page_size = PAGE_SIZE_DEFAULT
+        page_size = max(5, min(page_size, 200))
+
+        paginator = Paginator(qs, page_size)
+        page_number = request.GET.get("page") or 1
+        page_obj = paginator.get_page(page_number)
+
+        # Mantener querystring sin 'page' para paginación
+        qd = request.GET.copy()
+        qd.pop("page", None)
+        preserved_qs = qd.urlencode()
+
+        ctx.update(
+            {
+                "filter_form": filter_form,
+                "page_obj": page_obj,
+                "paginator": paginator,
+                "preserved_qs": preserved_qs,
+                "page_size": page_size,
+                "total_count": paginator.count,
+            }
+        )
+        return ctx
+
+
+# ========================
+# Alta (página)
+# ========================
+class ClienteNuevoView(TemplateView):
+    """Alta de cliente mediante página completa."""
+
+    template_name = "facturacion/cliente_form_page.html"
+
+    def get(self, request, *args, **kwargs):
+        form = ClienteForm()
+        return render(
+            request,
+            self.template_name,
+            {"form": form, "titulo": "Nuevo cliente", "accion_label": "Crear"},
+        )
+
+    def post(self, request, *args, **kwargs):
+        form = ClienteForm(request.POST)
+        if form.is_valid():
+            cliente = form.save()
+            logger.info("Cliente creado id=%s razon=%s", cliente.id, cliente.razon_social)
+            return redirect(reverse("clientes-list"))
+        return render(
+            request,
+            self.template_name,
+            {"form": form, "titulo": "Nuevo cliente", "accion_label": "Crear"},
+        )
+
+
+# ========================
+# Edición (página + modal)
+# ========================
+class ClienteEditarView(TemplateView):
+    """Edita cliente. Si la request es AJAX devuelve el fragmento del form."""
+
+    template_name = "facturacion/cliente_form_page.html"
+    partial_template = "facturacion/partials/cliente_form.html"
+
+    def get(self, request, id: int, *args, **kwargs):
+        cliente = get_object_or_404(Cliente, pk=id)
+        form = ClienteForm(instance=cliente)
+        if _is_ajax(request):
+            return render(
+                request,
+                self.partial_template,
+                {
+                    "form": form,
+                    "cliente": cliente,
+                    "action_url": reverse("clientes-editar", args=[cliente.id]),
+                    "modo": "editar",
+                },
+            )
+        return render(
+            request,
+            self.template_name,
+            {
+                "form": form,
+                "cliente": cliente,
+                "titulo": f"Editar cliente: {cliente.razon_social}",
+                "accion_label": "Guardar",
+            },
+        )
+
+    def post(self, request, id: int, *args, **kwargs):
+        cliente = get_object_or_404(Cliente, pk=id)
+        form = ClienteForm(request.POST, instance=cliente)
+        if form.is_valid():
+            cliente = form.save()
+            logger.info("Cliente editado id=%s", cliente.id)
+            if _is_ajax(request):
+                return JsonResponse(
+                    {"ok": True, "cliente": cliente_to_dict(cliente)}
+                )
+            return redirect(reverse("clientes-list"))
+        if _is_ajax(request):
+            html = render(
+                request,
+                self.partial_template,
+                {
+                    "form": form,
+                    "cliente": cliente,
+                    "action_url": reverse("clientes-editar", args=[cliente.id]),
+                    "modo": "editar",
+                },
+            ).content.decode("utf-8")
+            return JsonResponse({"ok": False, "html": html}, status=400)
+        return render(
+            request,
+            self.template_name,
+            {
+                "form": form,
+                "cliente": cliente,
+                "titulo": f"Editar cliente: {cliente.razon_social}",
+                "accion_label": "Guardar",
+            },
+        )
+
+
+# ========================
+# Eliminación con reasignación
+# ========================
+class ClienteEliminarView(TemplateView):
+    """Elimina un cliente reasignando sus transacciones a un cliente destino."""
+
+    template_name = "facturacion/partials/cliente_delete.html"
+
+    def get(self, request, id: int, *args, **kwargs):
+        cliente = get_object_or_404(Cliente, pk=id)
+        transacciones_count = Transaccion.objects.filter(cliente=cliente).count()
+        destinos = (
+            Cliente.objects.exclude(pk=cliente.pk)
+            .order_by("razon_social")
+        )
+        ctx = {
+            "cliente": cliente,
+            "transacciones_count": transacciones_count,
+            "destinos": destinos,
+            "default_destino_id": CONSUMIDOR_FINAL_ID,
+            "action_url": reverse("clientes-eliminar", args=[cliente.id]),
+        }
+        return render(request, self.template_name, ctx)
+
+    def post(self, request, id: int, *args, **kwargs):
+        cliente = get_object_or_404(Cliente, pk=id)
+        if cliente.pk == CONSUMIDOR_FINAL_ID:
+            msg = "No se puede eliminar el cliente Consumidor Final (pk=1)."
+            logger.warning(msg)
+            if _is_ajax(request):
+                return JsonResponse({"ok": False, "error": msg}, status=400)
+            return HttpResponse(msg, status=400)
+
+        destino_id = request.POST.get("destino_id") or CONSUMIDOR_FINAL_ID
+        try:
+            destino_id = int(destino_id)
+        except (TypeError, ValueError):
+            destino_id = CONSUMIDOR_FINAL_ID
+
+        if destino_id == cliente.pk:
+            msg = "El cliente destino no puede ser el mismo que se elimina."
+            if _is_ajax(request):
+                return JsonResponse({"ok": False, "error": msg}, status=400)
+            return HttpResponse(msg, status=400)
+
+        destino = get_object_or_404(Cliente, pk=destino_id)
+
+        try:
+            with db_transaction.atomic():
+                reasignadas = Transaccion.objects.filter(cliente=cliente).update(
+                    cliente=destino
+                )
+                cliente_repr = f"{cliente.razon_social} (id={cliente.pk})"
+                cliente.delete()
+                logger.info(
+                    "Cliente eliminado %s. Transacciones reasignadas=%s destino=%s (id=%s)",
+                    cliente_repr,
+                    reasignadas,
+                    destino.razon_social,
+                    destino.pk,
+                )
+        except Exception as e:
+            logger.error("Error eliminando cliente id=%s", id, exc_info=True)
+            if _is_ajax(request):
+                return JsonResponse({"ok": False, "error": str(e)}, status=500)
+            return HttpResponse(f"Error: {e}", status=500)
+
+        if _is_ajax(request):
+            return JsonResponse(
+                {
+                    "ok": True,
+                    "reasignadas": reasignadas,
+                    "destino": cliente_to_dict(destino),
+                }
+            )
+        return redirect(reverse("clientes-list"))
+
+
+# ========================
+# API: Alta rápida desde buscador
+# ========================
+@require_POST
+def api_crear_cliente(request):
+    """Crea un cliente desde el buscador y devuelve su representación JSON."""
+    # Aceptamos tanto application/json como form-data
+    if request.content_type and "application/json" in request.content_type:
+        try:
+            payload = json.loads(request.body or b"{}")
+        except json.JSONDecodeError:
+            return JsonResponse({"ok": False, "error": "JSON inválido"}, status=400)
+        form = ClienteQuickForm(payload)
+    else:
+        form = ClienteQuickForm(request.POST)
+
+    if not form.is_valid():
+        return JsonResponse({"ok": False, "errors": form.errors}, status=400)
+
+    cliente = form.save()
+    logger.info("Cliente creado (quick) id=%s razon=%s", cliente.id, cliente.razon_social)
+    return JsonResponse({"ok": True, "cliente": cliente_to_dict(cliente)}, status=201)

--- a/pedido/templates/pedido/base_pedido.html
+++ b/pedido/templates/pedido/base_pedido.html
@@ -21,7 +21,31 @@
 <body>
     <script src="{% static 'cookies/js-cookies3.min.js' %}"></script>
     <script src="{% static 'bootstrap/js/bootstrap.bundle.js' %}"></script>
-    <script src="{% static 'quagga/quagga.js' %}"></script>
+    {# Carga diferida de QuaggaJS: solo al activar el escaner.
+       Evita warnings asm.js de Firefox y reduce el parse JS inicial. #}
+    <script>
+        (function() {
+            var quaggaPromise = null;
+            window.loadQuagga = function() {
+                if (quaggaPromise) return quaggaPromise;
+                quaggaPromise = new Promise(function(resolve, reject) {
+                    var s = document.createElement('script');
+                    s.src = "{% static 'quagga/quagga.js' %}";
+                    s.async = true;
+                    s.onload = function() { resolve(window.Quagga); };
+                    s.onerror = function() { quaggaPromise = null; reject(new Error('No se pudo cargar Quagga')); };
+                    document.head.appendChild(s);
+                });
+                return quaggaPromise;
+            };
+            document.addEventListener('click', function(e) {
+                var t = e.target;
+                if (t && t.closest && t.closest('#scan-button')) {
+                    window.loadQuagga();
+                }
+            }, true);
+        })();
+    </script>
     
     {% block cuerpo %}
     {% endblock %}

--- a/pedido/templates/pedido/base_pedido.html
+++ b/pedido/templates/pedido/base_pedido.html
@@ -11,7 +11,7 @@
     <link href="{% static 'pedido/css/pedido.css' %}" rel="stylesheet">
     <title>{% block title %}  {% endblock%}</title>
     <link rel="stylesheet" type="text/css" href="{% static 'admin/css/widgets.css' %}">
-    <link rel="shortcut icon" type="image/png" href="/media/imagenes/favicon.ico"/>
+    <link rel="icon" type="image/svg+xml" href="{% static 'imagenes/favicon.svg' %}"/>
     <script src="{% static 'jquery/jquery.js' %}"></script>
     <link href="{% static 'vendor/select2/css/select2.min.css' %}" rel="stylesheet" />
     

--- a/pedido/templates/pedido/base_pedido.html
+++ b/pedido/templates/pedido/base_pedido.html
@@ -21,8 +21,10 @@
 <body>
     <script src="{% static 'cookies/js-cookies3.min.js' %}"></script>
     <script src="{% static 'bootstrap/js/bootstrap.bundle.js' %}"></script>
-    {# Carga diferida de QuaggaJS: solo al activar el escaner.
-       Evita warnings asm.js de Firefox y reduce el parse JS inicial. #}
+    {% comment %}
+        Carga diferida de QuaggaJS: solo al activar el escaner.
+        Evita warnings asm.js de Firefox y reduce el parse JS inicial.
+    {% endcomment %}
     <script>
         (function() {
             var quaggaPromise = null;

--- a/static/imagenes/favicon.svg
+++ b/static/imagenes/favicon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0dcaf0"/>
+      <stop offset="100%" stop-color="#0a93b0"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#bg)"/>
+  <!-- Llave inglesa -->
+  <g transform="rotate(-45 32 32)" fill="none" stroke="#fff" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 18 a8 8 0 1 0 8 8 l16 16 a4 4 0 0 0 5.6 0 l2.4 -2.4 a4 4 0 0 0 0 -5.6 l-16 -16 a8 8 0 0 0 -8 -8 z"/>
+  </g>
+  <!-- Martillo -->
+  <g transform="rotate(45 32 32)" fill="#fd7e14" stroke="#7a3a00" stroke-width="2" stroke-linejoin="round">
+    <rect x="14" y="26" width="20" height="12" rx="2"/>
+    <rect x="32" y="30" width="20" height="4" rx="1.5"/>
+  </g>
+</svg>

--- a/static/templates/generic_template.html
+++ b/static/templates/generic_template.html
@@ -10,7 +10,7 @@
         <link href="{% static 'bootstrap/css/bootstrap.css' %}" rel="stylesheet">
         <title>{% block title %}  {% endblock%}</title>
         <link rel="stylesheet" type="text/css" href="{% static 'admin/css/widgets.css' %}">
-        <link rel="shortcut icon" type="image/png" href="/media/imagenes/favicon.ico"/>
+        <link rel="icon" type="image/svg+xml" href="{% static 'imagenes/favicon.svg' %}"/>
         <script src="{% static 'jquery/jquery.js' %}"></script>
 
         <style>

--- a/static/templates/generic_template.html
+++ b/static/templates/generic_template.html
@@ -57,9 +57,11 @@
     <body data-usuario="{{ user.get_username }}">
         <script src="{% static 'cookies/js-cookies3.min.js' %}"></script>
         <script src="{% static 'bootstrap/js/bootstrap.bundle.js' %}"></script>
-        {# Carga diferida de QuaggaJS: solo cuando el usuario invoca el escaner.
-           Evita el warning de Firefox 'asm.js optimizer disabled because debugger
-           is active' en paginas que no usan scanner, y reduce el parse JS inicial. #}
+        {% comment %}
+            Carga diferida de QuaggaJS: solo cuando el usuario invoca el escaner.
+            Evita el warning de Firefox 'asm.js optimizer disabled because debugger
+            is active' en paginas que no usan scanner, y reduce el parse JS inicial.
+        {% endcomment %}
         <script>
             (function() {
                 var quaggaPromise = null;

--- a/static/templates/generic_template.html
+++ b/static/templates/generic_template.html
@@ -57,7 +57,32 @@
     <body data-usuario="{{ user.get_username }}">
         <script src="{% static 'cookies/js-cookies3.min.js' %}"></script>
         <script src="{% static 'bootstrap/js/bootstrap.bundle.js' %}"></script>
-        <script src="{% static 'quagga/quagga.js' %}"></script>
+        {# Carga diferida de QuaggaJS: solo cuando el usuario invoca el escaner.
+           Evita el warning de Firefox 'asm.js optimizer disabled because debugger
+           is active' en paginas que no usan scanner, y reduce el parse JS inicial. #}
+        <script>
+            (function() {
+                var quaggaPromise = null;
+                window.loadQuagga = function() {
+                    if (quaggaPromise) return quaggaPromise;
+                    quaggaPromise = new Promise(function(resolve, reject) {
+                        var s = document.createElement('script');
+                        s.src = "{% static 'quagga/quagga.js' %}";
+                        s.async = true;
+                        s.onload = function() { resolve(window.Quagga); };
+                        s.onerror = function() { quaggaPromise = null; reject(new Error('No se pudo cargar Quagga')); };
+                        document.head.appendChild(s);
+                    });
+                    return quaggaPromise;
+                };
+                document.addEventListener('click', function(e) {
+                    var t = e.target;
+                    if (t && t.closest && t.closest('#scan-button')) {
+                        window.loadQuagga();
+                    }
+                }, true);
+            })();
+        </script>
 
         
         {% load socialaccount %}

--- a/static/templates/plantilla_formulario.html
+++ b/static/templates/plantilla_formulario.html
@@ -3,7 +3,7 @@
 <div class="row">
     <div class="row">
     
-        <div id="botonesCarrito" style="height: 40px">
+        <div id="botonesCarrito" class="d-flex flex-wrap gap-2 mb-3 px-2">
             <!-- Aquí se añadirán los botones de los carritos -->
         </div>
     </div>

--- a/static/templates/plantilla_formulario.html
+++ b/static/templates/plantilla_formulario.html
@@ -87,3 +87,27 @@
         {% include "tabla_link_pedidos.html" %}
     </div>
 </div>
+
+{# Select2 para el campo sub_titulo (FK -> Sub_Titulo) #}
+<link href="{% static 'vendor/select2/css/select2.min.css' %}" rel="stylesheet">
+<script src="{% static 'vendor/select2/js/select2.min.js' %}"></script>
+<script>
+    (function() {
+        function initSubtituloSelect2() {
+            if (!window.jQuery || !jQuery.fn || !jQuery.fn.select2) return;
+            var $sel = jQuery('#id_sub_titulo');
+            if ($sel.length && !$sel.hasClass('select2-hidden-accessible')) {
+                $sel.select2({
+                    width: '100%',
+                    placeholder: 'Seleccionar subtítulo...',
+                    allowClear: true
+                });
+            }
+        }
+        if (window.jQuery) {
+            jQuery(initSubtituloSelect2);
+        } else {
+            document.addEventListener('DOMContentLoaded', initSubtituloSelect2);
+        }
+    })();
+</script>

--- a/static/templates/tabla_buscador.html
+++ b/static/templates/tabla_buscador.html
@@ -368,9 +368,11 @@
         
         
         // Cuando el usuario hace clic en el botón de cierre del modal, cierra el modal
-        var span = document.getElementsByClassName("close")[0];
-        span.onclick = function() {
-            document.getElementById('ModalCarrito').style.display = "none";  // Oculta el modal
+        var span = document.getElementsByClassName("close_carrito")[0];
+        if (span) {
+            span.onclick = function() {
+                document.getElementById('ModalCarrito').style.display = "none";  // Oculta el modal
+            }
         }
         
         var csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;

--- a/static/templates/tabla_lateral_carritos.html
+++ b/static/templates/tabla_lateral_carritos.html
@@ -1,12 +1,129 @@
 <!-- tabla_lateral_carritos.html -->
 
 <style>
+    /* ===== Carrito lateral ===== */
+    #tablaCarrito {
+        --card-bg: rgba(255, 255, 255, 0.95);
+        --card-border: rgba(0, 0, 0, 0.08);
+        --muted-fg: rgba(0, 0, 0, 0.6);
+        box-shadow: -8px 0 24px rgba(0, 0, 0, 0.18);
+        padding-bottom: 1rem;
+    }
     @media (max-width: 768px) {
         #tablaCarrito {
             width: 95% !important;
         }
     }
-    /* Loading indicator style */
+    @media (min-width: 1400px) {
+        #tablaCarrito {
+            width: 520px !important;
+        }
+    }
+
+    /* Header fijo del carrito */
+    #tablaCarrito .cart-header {
+        position: -webkit-sticky; /* Safari */
+        position: sticky;
+        top: 0;
+        z-index: 2;
+        background: inherit; /* fallback sólido si no hay backdrop-filter */
+        -webkit-backdrop-filter: blur(6px); /* Safari/iOS */
+        backdrop-filter: blur(6px);
+        border-bottom: 1px solid var(--card-border);
+        padding: 0.75rem 1rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+    }
+    #tablaCarrito .cart-title {
+        font-weight: 600;
+        font-size: 1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        margin: 0;
+    }
+    #tablaCarrito .cart-title small {
+        opacity: 0.75;
+        font-weight: 400;
+    }
+
+    /* Tarjetas internas */
+    #tablaCarrito .cart-card {
+        background: var(--card-bg);
+        border: 1px solid var(--card-border);
+        border-radius: 10px;
+        padding: 0.9rem;
+        margin: 0.75rem 1rem;
+        color: #212529;
+    }
+    #tablaCarrito .cart-card .section-title {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.8rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        color: var(--muted-fg);
+        margin-bottom: 0.6rem;
+    }
+
+    /* Inputs compactos y alineados */
+    #tablaCarrito .form-control,
+    #tablaCarrito .form-select {
+        font-size: 0.925rem;
+    }
+
+    /* Tabla de artículos */
+    #tablaCarrito #tabla-articulos {
+        margin-bottom: 0;
+    }
+    #tablaCarrito #tabla-articulos thead th {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        color: var(--muted-fg);
+        border-bottom: 1px solid var(--card-border);
+        background: transparent;
+        padding: 0.5rem 0.5rem;
+    }
+    #tablaCarrito #tabla-articulos tbody td {
+        vertical-align: middle;
+        padding: 0.5rem 0.5rem;
+    }
+    #tablaCarrito #tabla-articulos tbody input[type=number].cantidad-articulo {
+        width: 64px !important;
+        padding: 0.15rem 0.35rem;
+        border: 1px solid var(--card-border);
+        border-radius: 6px;
+    }
+    #tablaCarrito #tabla-articulos tbody button.eliminar-articulo {
+        padding: 0.1rem 0.5rem;
+        font-size: 0.8rem;
+        line-height: 1.2;
+    }
+    /* Filas de totales (últimas 2, aportadas por el JS con "Total" y "Total Efectivo") */
+    #tablaCarrito #tabla-articulos tbody tr:nth-last-child(-n+2) td {
+        font-weight: 600;
+        border-top: 1px solid var(--card-border);
+        background: rgba(0, 0, 0, 0.03);
+    }
+
+    /* Botones del formulario de transacción */
+    #tablaCarrito .btn-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+    }
+    #tablaCarrito .btn-row .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+    }
+
+    /* Loading indicator */
     .loading-indicator {
         display: none;
         position: fixed;
@@ -16,94 +133,206 @@
         padding: 5px 10px;
         border-radius: 3px;
         font-size: 12px;
-        z-index: 1000;
+        z-index: 1060;
+    }
+
+    /* Iconos SVG inline */
+    .icon {
+        width: 16px;
+        height: 16px;
+        flex: 0 0 16px;
+        stroke: currentColor;
+        fill: none;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
     }
 </style>
 
 <!-- Loading indicator -->
-<div id="cartLoading" class="loading-indicator">Actualizando carrito...</div>
+<div id="cartLoading" class="loading-indicator">Actualizando carrito…</div>
 
 <div id="tablaCarrito" class="position-fixed top-0 end-0" style="width: 50%; height: 100%; overflow: auto; display: none; background-color: white; z-index: 1050;">
-    
-<div class="p-3">
-    <div class='row'>
-        <button id="cerrarCarrito" class="btn btn-secondary">Cerrar</button>
-    </div>
-</div>
 
-<!-- Rest of your existing HTML remains unchanged -->
-<div class="p-3">
-    <div class="card">
-        <!-- Aqui un form -->
+    <!-- Header -->
+    <div class="cart-header">
+        <h2 class="cart-title">
+            <svg class="icon" viewBox="0 0 24 24"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.7 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/></svg>
+            <span>Carrito</span>
+            <small id="cartHeaderNombre"></small>
+        </h2>
+        <button id="cerrarCarrito" class="btn btn-sm btn-secondary" title="Cerrar" aria-label="Cerrar">
+            <svg class="icon" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            <span class="d-none d-sm-inline">Cerrar</span>
+        </button>
+    </div>
+
+    <!-- Sección: Datos de la transacción -->
+    <div class="cart-card">
+        <div class="section-title">
+            <svg class="icon" viewBox="0 0 24 24"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+            Transacción
+        </div>
         <form id="formTransaccion" method="post">
             <input type="hidden" id="usuario" name="usuario" value="">
             <input type="hidden" id="carrito_id" name="carrito_id" value="">
             <input type="hidden" id="articulos_vendidos" name="articulos_vendidos" value="">
-            <select id="cliente_id" name="cliente_id" required>
-                <option value="">-------</option>
-            </select>
-            <input type="text" id="buscar_cliente" placeholder="Buscar cliente">
-            <select id="metodo_de_pago" name="metodo_de_pago"></select>
             <input type="hidden" id="total" name="total" value="">
             <input type="hidden" id="total_efectivo" name="total_efectivo" value="">
-            <button id="enviar-transaccion"  type="submit" class="btn btn-primary">Cerrar Transacción</button>
-            <button type="button" class="btn btn-secondary" id="nuevoCliente"> + Cliente</button>
+
+            <div class="mb-2">
+                <label class="form-label mb-1 small text-muted" for="cliente_id">Cliente</label>
+                <select id="cliente_id" name="cliente_id" class="form-select form-select-sm" required>
+                    <option value="">— Seleccionar cliente —</option>
+                </select>
+            </div>
+
+            <div class="input-group input-group-sm mb-2">
+                <span class="input-group-text">
+                    <svg class="icon" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                </span>
+                <input type="text" id="buscar_cliente" class="form-control" placeholder="Buscar cliente...">
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label mb-1 small text-muted" for="metodo_de_pago">Método de pago</label>
+                <select id="metodo_de_pago" name="metodo_de_pago" class="form-select form-select-sm"></select>
+            </div>
+
+            <div class="btn-row">
+                <button id="enviar-transaccion" type="submit" class="btn btn-primary btn-sm">
+                    <svg class="icon" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>
+                    Cerrar Transacción
+                </button>
+                <button type="button" class="btn btn-success btn-sm" id="nuevoCliente" data-bs-toggle="modal" data-bs-target="#modalNuevoCliente">
+                    <svg class="icon" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                    Cliente
+                </button>
+                <button type="button" class="btn btn-outline-secondary btn-sm" id="verClientes">
+                    <svg class="icon" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                    Clientes
+                </button>
+            </div>
         </form>
     </div>
-</div>
 
 <div class="modal fade" id="modalNuevoCliente" tabindex="-1" role="dialog" aria-labelledby="modalNuevoClienteLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
+    <div class="modal-dialog modal-dialog-centered" role="document">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="modalNuevoClienteLabel">Nuevo Cliente</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">×</span>
-          </button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
         </div>
         <div class="modal-body">
-          <form id="formNuevoCliente" method="post">
-            <input type="text" id="razon_social" name="razon_social" placeholder="Razón Social">
-            <input type="text" id="cuit_dni" name="cuit_dni" placeholder="CUIT/DNI">
-            <button type="submit" class="btn btn-primary">Guardar</button>
+          <form id="formNuevoCliente">
+            <div id="formNuevoClienteErrors" class="alert alert-danger d-none"></div>
+            <div class="row g-2">
+                <div class="col-12">
+                    <label class="form-label mb-0 small">Razón Social</label>
+                    <input type="text" class="form-control" id="qc_razon_social" name="razon_social" required>
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label mb-0 small">CUIT/DNI</label>
+                    <input type="text" class="form-control" id="qc_cuit_dni" name="cuit_dni" required>
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label mb-0 small">Tipo Documento</label>
+                    <select class="form-select" id="qc_tipo_documento" name="tipo_documento">
+                        <option value=" " selected>Sin calificador</option>
+                        <option value="C">CUIT</option>
+                        <option value="2">Documento Nacional de Identidad</option>
+                        <option value="0">Libreta de enrolamiento</option>
+                        <option value="1">Libreta cívica</option>
+                        <option value="3">Pasaporte</option>
+                        <option value="4">Cédula de identidad</option>
+                    </select>
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label mb-0 small">Responsabilidad IVA</label>
+                    <select class="form-select" id="qc_responsabilidad_iva" name="responsabilidad_iva">
+                        <option value="C" selected>Consumidor final</option>
+                        <option value="I">Responsable inscripto</option>
+                        <option value="E">Exento</option>
+                        <option value="A">No responsable</option>
+                        <option value="B">Responsable no inscripto, venta de bienes de uso</option>
+                        <option value="M">Resp. monotributo</option>
+                        <option value="S">Monotributista social</option>
+                        <option value="V">Pequeño contribuyente eventual</option>
+                        <option value="W">Pequeño contribuyente eventual social</option>
+                        <option value="T">No categorizado</option>
+                    </select>
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label mb-0 small">Teléfono</label>
+                    <input type="text" class="form-control" id="qc_telefono" name="telefono">
+                </div>
+                <div class="col-12">
+                    <label class="form-label mb-0 small">Domicilio</label>
+                    <input type="text" class="form-control" id="qc_domicilio" name="domicilio">
+                </div>
+            </div>
+            <div class="d-flex justify-content-end gap-2 mt-3">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button type="submit" class="btn btn-primary">Guardar</button>
+            </div>
           </form>
         </div>
       </div>
     </div>
 </div>
 
-<div class="p-3">
-    <div class="card">
+    <!-- Sección: Agregar artículo sin registro -->
+    <div class="cart-card">
+        <div class="section-title">
+            <svg class="icon" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            Agregar artículo
+        </div>
         <form id="formArticuloSinRegistro" method="post">
-            <div class= "row p-0 m-0">
-                <input type="text" id="descripcion" name="descripcion" placeholder="Descripción" value="Generico" required>
+            <div class="mb-2">
+                <label class="form-label mb-1 small text-muted" for="descripcion">Descripción</label>
+                <input type="text" id="descripcion" name="descripcion" class="form-control form-control-sm" value="Generico" required>
             </div>
-            <div class= "colum p-0 m-0">
-                <input type="number" id="cantidad" name="cantidad" placeholder="Cantidad" step="0.01" value="1" required>
-                <input type="number" id="precio" name="precio" placeholder="Precio" step="0.01" value="" required>
-                <button type="submit" class="btn btn-primary">Agregar Artículo</button>
+            <div class="row g-2 align-items-end">
+                <div class="col-4">
+                    <label class="form-label mb-1 small text-muted" for="cantidad">Cantidad</label>
+                    <input type="number" id="cantidad" name="cantidad" class="form-control form-control-sm" step="0.01" value="1" required>
+                </div>
+                <div class="col-4">
+                    <label class="form-label mb-1 small text-muted" for="precio">Precio</label>
+                    <input type="number" id="precio" name="precio" class="form-control form-control-sm" step="0.01" placeholder="0.00" required>
+                </div>
+                <div class="col-4 d-grid">
+                    <button type="submit" class="btn btn-primary btn-sm">
+                        <svg class="icon" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                        Agregar
+                    </button>
+                </div>
             </div>
         </form>
     </div>
-</div>
 
-<div class="p-3">
-    <div class="card">
-        <table id="tabla-articulos" class="table">
-            <thead>
-                <tr>
-                    <th>Item</th>
-                    <th>Cantidad</th>
-                    <th>Precio</th>
-                    <th>Borrar</th>
-                </tr>
-            </thead>
-            <tbody>
-                <!-- Aquí se llenará la tabla con los datos del carrito -->
-            </tbody>
-        </table>
+    <!-- Sección: Tabla de artículos -->
+    <div class="cart-card">
+        <div class="section-title">
+            <svg class="icon" viewBox="0 0 24 24"><path d="M3 6h18"/><path d="M3 12h18"/><path d="M3 18h18"/></svg>
+            Artículos
+        </div>
+        <div class="table-responsive">
+            <table id="tabla-articulos" class="table table-sm table-borderless align-middle mb-0">
+                <thead>
+                    <tr>
+                        <th>Item</th>
+                        <th class="text-center" style="width:90px;">Cantidad</th>
+                        <th class="text-end" style="width:80px;">Precio</th>
+                        <th class="text-center" style="width:50px;">Borrar</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- Aquí se llenará la tabla con los datos del carrito -->
+                </tbody>
+            </table>
+        </div>
     </div>
-</div>
 
 </div>
 
@@ -223,9 +452,71 @@ document.getElementById('enviar-transaccion').addEventListener('click', function
     }
 });
 
-document.getElementById('nuevoCliente').onclick = function () {
+// Botón "Clientes": abre el listado (CRUD)
+document.getElementById('verClientes').onclick = function () {
     window.location.href = "/facturacion/clientes/";
 };
+
+// Helper CSRF
+function _qcGetCookie(name) {
+    const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+    return match ? decodeURIComponent(match[1]) : null;
+}
+
+// Mover el modal fuera del contenedor #tablaCarrito (position:fixed con z-index)
+// para evitar que el backdrop de Bootstrap quede por encima del modal.
+(function(){
+    const modal = document.getElementById('modalNuevoCliente');
+    if (modal && modal.parentElement && modal.parentElement.id !== 'body-modals-root') {
+        document.body.appendChild(modal);
+    }
+})();
+
+// Submit del modal de alta rápida de cliente
+document.getElementById('formNuevoCliente').addEventListener('submit', function(e){
+    e.preventDefault();
+    const form = e.target;
+    const errors = document.getElementById('formNuevoClienteErrors');
+    errors.classList.add('d-none');
+    errors.textContent = '';
+    const payload = {
+        razon_social: document.getElementById('qc_razon_social').value,
+        cuit_dni: document.getElementById('qc_cuit_dni').value,
+        tipo_documento: document.getElementById('qc_tipo_documento').value,
+        responsabilidad_iva: document.getElementById('qc_responsabilidad_iva').value,
+        telefono: document.getElementById('qc_telefono').value,
+        domicilio: document.getElementById('qc_domicilio').value,
+    };
+    fetch('/facturacion/clientes/api/crear/', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': _qcGetCookie('csrftoken'),
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify(payload),
+    }).then(async r => {
+        const data = await r.json().catch(() => ({}));
+        if (r.ok && data.ok) {
+            const c = data.cliente;
+            const select = $("#cliente_id");
+            select.append('<option value="' + c.id + '">' + c.razon_social + ' (' + c.cuit_dni + ')</option>');
+            select.val(c.id);
+            form.reset();
+            const modalEl = document.getElementById('modalNuevoCliente');
+            const modal = bootstrap.Modal.getInstance(modalEl) || new bootstrap.Modal(modalEl);
+            modal.hide();
+        } else {
+            const errs = data.errors || {error: data.error || 'Error al crear cliente'};
+            errors.textContent = typeof errs === 'string' ? errs : Object.entries(errs).map(([k,v]) => k + ': ' + (Array.isArray(v)?v.join(', '):v)).join(' | ');
+            errors.classList.remove('d-none');
+        }
+    }).catch(err => {
+        errors.textContent = 'Error de red: ' + err;
+        errors.classList.remove('d-none');
+    });
+});
 
 $(document).ready(function(){
     // Iniciar la actualización automática
@@ -268,6 +559,14 @@ $(document).ready(function(){
             var texto = $(this).text().toLowerCase();
             $(this).toggle(texto.indexOf(buscar) > -1);
         });
+    });
+
+    // Guardar la selección de cliente por carrito visible
+    $(document).on('change', '#cliente_id', function() {
+        const nombre = $("#tablaCarrito").data("nombre");
+        if (!nombre) return;
+        window.clienteSeleccionadoPorCarrito = window.clienteSeleccionadoPorCarrito || {};
+        window.clienteSeleccionadoPorCarrito[nombre] = $(this).val() || "";
     });
 
     $("#metodo_de_pago").change(function() {
@@ -320,7 +619,12 @@ $(document).ready(function(){
                 tbody.append('<tr><td>Total</td><td></td><td>' + data[nombre].total + '</td><td></td></tr>');
                 tbody.append('<tr><td>Total Efectivo</td><td></td><td>' + data[nombre].total_efectivo + '</td><td></td></tr>');
                 
+                // Detectar si cambió el carrito visible (no es un mero auto-refresh)
+                const prevNombre = $("#tablaCarrito").data("nombre");
+                const cartChanged = prevNombre !== nombre;
+
                 $("#tablaCarrito").data("nombre", nombre);
+                $("#cartHeaderNombre").text(nombre ? ('· ' + nombre) : '');
                 $("#carrito_id").val(data[nombre].carrito_id);
                 const bgColor = data[nombre].color || 'white';
                 const fgColor = getTextColorForBg(bgColor);
@@ -328,12 +632,24 @@ $(document).ready(function(){
                     "background-color": bgColor,
                     "color": fgColor
                 });
-                // ajustar botones internos si los hubiera
-                $("#tablaCarrito .btn").css({
-                    "border-color": fgColor,
-                    "color": fgColor
-                });
-                $("#cliente_id").val("");
+                // ajustar SOLO botones genéricos (sin variante Bootstrap propia)
+                // para no romper el contraste de #enviar-transaccion, #nuevoCliente,
+                // #verClientes, #cerrarCarrito, etc.
+                $("#tablaCarrito .btn")
+                    .not("#enviar-transaccion, #nuevoCliente, #verClientes, #cerrarCarrito, .btn-primary, .btn-success, .btn-danger, .btn-warning, .btn-info, .btn-outline-secondary, .btn-secondary")
+                    .css({
+                        "border-color": fgColor,
+                        "color": fgColor
+                    });
+                // Persistencia por carrito del cliente seleccionado
+                window.clienteSeleccionadoPorCarrito = window.clienteSeleccionadoPorCarrito || {};
+                if (cartChanged) {
+                    // Restaurar selección previa para este carrito (si existe)
+                    const prevSel = window.clienteSeleccionadoPorCarrito[nombre] || "";
+                    $("#cliente_id").val(prevSel);
+                    $("#buscar_cliente").val("");
+                    $("#cliente_id option").show();
+                }
 
                 // Actualizar métodos de pago
                 $.ajax({
@@ -441,8 +757,9 @@ $(document).ready(function(){
         dataType: 'json',
         success: function(users) {
             if (Array.isArray(users) && users.length > 0) {
-                const wrap = $('<div id="selectorCajeroWrap" class="p-3"><label for="selectorCajero" class="form-label">Seleccionar cajero</label><select id="selectorCajero" class="form-select"><option value="">Todos</option></select></div>');
-                wrap.insertBefore('#tablaCarrito .p-3:first');
+                const wrap = $('<div id="selectorCajeroWrap" class="cart-card"><div class="section-title"><svg class="icon" viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a6 6 0 0 1 6-6h4a6 6 0 0 1 6 6v1"/></svg>Cajero</div><select id="selectorCajero" class="form-select form-select-sm"><option value="">Todos</option></select></div>');
+                // Insertar justo después del header, antes de la primera sección
+                wrap.insertBefore('#tablaCarrito .cart-card:first');
                 const sel = $('#selectorCajero');
                 users.forEach(function(u) {
                     sel.append('<option value="' + u.nombre + '">' + u.nombre + '</option>');
@@ -511,6 +828,13 @@ $(document).ready(function(){
                         $("#buscar_cliente").prop("disabled", true);
                         $("#cliente_id").prop("disabled", true);
                         $("#cliente_id").val("");
+                        $("#buscar_cliente").val("");
+                        // Mostrar nuevamente todas las opciones del select
+                        $("#cliente_id option").show();
+                        // Limpiar persistencia del carrito recién facturado
+                        if (window.clienteSeleccionadoPorCarrito && nombre) {
+                            delete window.clienteSeleccionadoPorCarrito[nombre];
+                        }
                     }
                 });
             }

--- a/static/templates/tabla_lateral_carritos.html
+++ b/static/templates/tabla_lateral_carritos.html
@@ -423,6 +423,10 @@ function updateCart(nombre) {
         data: (window.selectedUser && typeof window.selectedUser === 'string') ? { usuario: window.selectedUser } : {},
         dataType: 'json',
         success: function(data) {
+            // Actualizar badges de cantidad en los botones de carrito
+            if (typeof window.actualizarBadgesBotonesCarrito === 'function') {
+                window.actualizarBadgesBotonesCarrito(data);
+            }
             // Verificar si hay cambios antes de actualizar
             const currentData = JSON.stringify(data);
             if (lastCartData !== currentData) {
@@ -605,6 +609,9 @@ $(document).ready(function(){
             dataType: 'json',
             success: function(data) {
                 lastCartData = JSON.stringify(data); // Actualizar los datos del carrito
+                if (typeof window.actualizarBadgesBotonesCarrito === 'function') {
+                    window.actualizarBadgesBotonesCarrito(data);
+                }
                 var tbody = $("#tablaCarrito table tbody");
                 tbody.empty();
                 
@@ -728,7 +735,46 @@ $(document).ready(function(){
     function getColorSeguro(color) {
         return color || 'white';
     }
-    
+
+    // Cuenta total de lineas de articulos (registrados + sin registro)
+    function contarArticulos(info) {
+        if (!info) return 0;
+        var a = Array.isArray(info.articulos) ? info.articulos.length : 0;
+        var b = Array.isArray(info.articulos_sin_registro) ? info.articulos_sin_registro.length : 0;
+        return a + b;
+    }
+
+    // HTML de un boton de carrito con badge de cantidad (similar al navbar)
+    window.buildBotonCarritoHTML = function(nombre, info) {
+        var color = getColorSeguro(info.color);
+        var tcolor = getTextColorForBg(color);
+        var count = contarArticulos(info);
+        var badge = count > 0
+            ? '<span class="badge-carrito position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">' + count + '<span class="visually-hidden">articulos</span></span>'
+            : '';
+        return '<button id="botonCarrito' + nombre + '" class="btn me-2 mb-2 position-relative" style="background-color:' + color + '; color:' + tcolor + '; border-color:' + tcolor + ';">Carrito de ' + nombre + badge + '</button>';
+    };
+
+    // Actualiza badges de los botones existentes a partir de data de /consultar_carrito/
+    window.actualizarBadgesBotonesCarrito = function(data) {
+        if (!data) return;
+        for (var nombre in data) {
+            var btn = $('#botonCarrito' + nombre);
+            if (!btn.length) continue;
+            var count = contarArticulos(data[nombre]);
+            var badge = btn.find('.badge-carrito');
+            if (count > 0) {
+                if (badge.length) {
+                    badge.contents().filter(function(){ return this.nodeType === 3; }).first().replaceWith(document.createTextNode(count));
+                } else {
+                    btn.append('<span class="badge-carrito position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">' + count + '<span class="visually-hidden">articulos</span></span>');
+                }
+            } else if (badge.length) {
+                badge.remove();
+            }
+        }
+    };
+
     function crearControlador(nombre) {
         return function() {
             mostrarCarrito(nombre);
@@ -742,9 +788,7 @@ $(document).ready(function(){
         dataType: 'json',
         success: function(data) {
             for (var nombre in data) {
-                let color = getColorSeguro(data[nombre].color);
-                let tcolor = getTextColorForBg(color);
-                $("#botonesCarrito").append('<button id="botonCarrito' + nombre + '" class="btn me-2 mb-2" style="background-color:' + color + '; color:' + tcolor + '; border-color:' + tcolor + ';">Carrito de ' + nombre + '</button>');
+                $("#botonesCarrito").append(window.buildBotonCarritoHTML(nombre, data[nombre]));
                 $("#botonCarrito" + nombre).click(crearControlador(nombre));
             }
         }
@@ -774,9 +818,7 @@ $(document).ready(function(){
                         $.get('/consultar_carrito/', function(data) {
                             $("#botonesCarrito").empty();
                             for (var nombre in data) {
-                                let color = getColorSeguro(data[nombre].color);
-                                let tcolor = getTextColorForBg(color);
-                                $("#botonesCarrito").append('<button id="botonCarrito' + nombre + '" class="btn me-2 mb-2" style="background-color:' + color + '; color:' + tcolor + '; border-color:' + tcolor + ';">Carrito de ' + nombre + '</button>');
+                                $("#botonesCarrito").append(window.buildBotonCarritoHTML(nombre, data[nombre]));
                                 $("#botonCarrito" + nombre).click(crearControlador(nombre));
                             }
                         });

--- a/x_cartel/templates/x_cartel/cartelitos_x6.html
+++ b/x_cartel/templates/x_cartel/cartelitos_x6.html
@@ -10,7 +10,7 @@
         <title>{% block title %}  {% endblock%}</title>
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
         <link rel="stylesheet" type="text/css" href="{% static 'admin/css/widgets.css' %}">
-        <link rel="shortcut icon" type="image/png" href="/media/imagenes/favicon.ico"/>
+        <link rel="icon" type="image/svg+xml" href="{% static 'imagenes/favicon.svg' %}"/>
 <!-- imprimir_carteles_x6.html -->
 <body>
 <div class="row row-cols-1 row-cols-md-2 g-0" style="width: 210mm">


### PR DESCRIPTION
## Descripción

Implementa el CRUD completo de Clientes para la app de facturación, junto con mejoras de UX en el carrito lateral.

## Cambios incluidos

### Backend
- **`facturacion/views_clientes.py`** (nuevo): vistas `ClientesListView`, `ClienteNuevoView`, `ClienteEditarView` (AJAX/modal), `ClienteEliminarView` (reasignación atómica de transacciones) y `api_crear_cliente`.
- **`facturacion/forms.py`**: `ClienteForm` con widgets Bootstrap; `ClienteQuickForm` con todos los campos; `ClienteFilterForm` para filtros del listado.
- **`facturacion/urls.py`**: rutas `clientes-list`, `clientes-nuevo`, `clientes-editar`, `clientes-eliminar`, `clientes-api-crear`; alias legacy conservado.

### Templates
- **`clientes_list.html`**: listado con filtros, paginación segura, tabla con íconos SVG, modales Bootstrap para edición/eliminación en línea.
- **`cliente_form_page.html`**: página completa de alta/edición.
- **`partials/cliente_form.html`**: fragmento del form para modal AJAX.
- **`partials/cliente_delete.html`**: confirmación de baja con selector de cliente destino (default pk=1 Consumidor Final).

### Carrito lateral (`tabla_lateral_carritos.html`)
- Refactor UI: tarjetas con header sticky, íconos SVG, layout Bootstrap compacto.
- Modal de alta rápida con todos los campos del cliente (razon_social, cuit_dni, tipo_documento, responsabilidad_iva, telefono, domicilio).
- Fix stacking context: modal movido a `<body>` al cargar.
- **Persistencia de cliente por carrito**: selección guardada en `clienteSeleccionadoPorCarrito[nombre]`; se restaura al volver al carrito, se limpia solo al cambiar de carrito o tras transacción exitosa.
- Fix: `buscar_cliente` se limpia post-transacción y restaura opciones del select.
- Fix contraste: botones con variante Bootstrap excluidos del recoloreo dinámico.
- CSS cross-browser: prefijos `-webkit-sticky` y `-webkit-backdrop-filter`.

## Notas
- La migración `0004_consumidor_final.py` (data migration para pk=1) no está trackeada por política del repo (`.gitignore`). Aplicar manualmente en cada entorno: `python manage.py migrate facturacion`.
- No hay cambios en modelos ni migraciones de esquema.
- Error preexistente `reportlab` en `pedido/views/pdf.py` no relacionado con este PR.